### PR TITLE
Add payment for tournaments

### DIFF
--- a/src/models/tournament.ts
+++ b/src/models/tournament.ts
@@ -20,6 +20,7 @@ interface BaseTournament {
   game: Game | Game['id'];
   manager_online_product: number;
   player_online_product: number;
+  substitute_online_product: number;
   maxTeam: number;
   validated_teams: number;
   description: string;

--- a/src/views/Me.vue
+++ b/src/views/Me.vue
@@ -10,11 +10,15 @@ import {
 import placeholder from '@/assets/images/logo_home.png';
 import FormField from '@/components/FormField.vue';
 import Modal from '@/components/Modal.vue';
+import type { Tournament } from '@/models/tournament';
+import { useTournamentStore } from '@/stores/tournament.store';
 import { useUserStore } from '@/stores/user.store';
 
 const userStore = useUserStore();
+const tournamentStore = useTournamentStore();
 const { user, role, inscriptions } = storeToRefs(userStore);
 const { fetch_user_inscription_full, patch_user } = userStore;
+const { payRegistration } = tournamentStore;
 
 onMounted(async () => {
   await fetch_user_inscription_full();
@@ -226,11 +230,12 @@ const editField = (field: string) => {
               <div class="m-1 flex h-8 flex-1 flex-col justify-center">
                 <div>
                   <a
-                    :class="{ [`bg-red-600`]: inscriptions.unpaid[inscription[1].team.id], [`bg-green-600`]: !inscriptions.unpaid[inscription[1].team.id] }"
+                    :class="{ [`bg-red-600`]: inscriptions.unpaid[inscription[1].id], [`bg-green-600`]: !inscriptions.unpaid[inscription[1].id] }"
                     class="center rounded p-2 font-bold text-white transition duration-150 ease-in-out hover:ring hover:ring-pink-500"
                     :href="`/tournament/${inscription[1].team.tournament.id }?s=teams`"
+                    @click.prevent="inscriptions.unpaid[inscription[1].id] ? payRegistration(inscription[1].team.tournament as unknown as Tournament, inscription[0]) : ''"
                   >
-                    {{ inscriptions.unpaid[inscription[1].team.id] ? 'Terminer l\'inscription' : (inscription[1].team.players[0] === user.id || inscription[0] === "manager") ? 'Gérer l\'équipe' : 'Voir l\'équipe' }}
+                    {{ inscriptions.unpaid[inscription[1].id] ? 'Terminer l\'inscription' : (inscription[1].team.players[0] === user.id || inscription[0] === "manager") ? 'Gérer l\'équipe' : 'Voir l\'équipe' }}
                   </a>
                 </div>
               </div>

--- a/src/views/TournamentRegister.vue
+++ b/src/views/TournamentRegister.vue
@@ -23,7 +23,9 @@ const { user } = useUserStore();
 
 const tournamentStore = useTournamentStore();
 
-const { registerTeam, registerPlayerOrManager, getTournamentFull } = tournamentStore;
+const {
+  registerTeam, registerPlayerOrManager, getTournamentFull, payRegistration,
+} = tournamentStore;
 const { tournamentsList } = storeToRefs(tournamentStore);
 const tournament = computed<Tournament | undefined>(() => tournamentsList.value[props.id]);
 // const tournament = ref<Tournament>();
@@ -101,7 +103,7 @@ const register_player = async () => {
 };
 
 const payment = async () => {
-  /* */
+  await payRegistration(tournament.value as Tournament, register_form.role);
 };
 
 const generate_password = () => {


### PR DESCRIPTION
- Fixed a bug where team id was used instead of registration id to apply the right class
- Add a backend api call to the payment endpoint with product id.

Because of the use of notifications, i was not able to test the entire workflow but "in theory", if the back is working as intended and the env file is the right, this should work fine as it only use axios interceptor to display error message and follow redirection.