### PR TITLE
Fix dockerfile version not static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine:latest
-
-RUN apk --no-cache add wget nodejs npm
+FROM node:20-alpine
 
 # CMD [ "cat", "/etc/resolv.conf" ]
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,4 @@
-FROM alpine:latest
-
-RUN apk --no-cache add wget nodejs bash npm
+FROM node:20-alpine
 
 # CMD [ "cat", "/etc/resolv.conf" ]
 


### PR DESCRIPTION
Fix a bug introduced with latest alpine build that was causing a node internal error by locking the image used and not using latest.