### PR TITLE
Fix tournament card mega tall because of fixed height

### DIFF
--- a/src/components/TournamentCard.vue
+++ b/src/components/TournamentCard.vue
@@ -24,7 +24,7 @@ onMounted(async () => {
     <img
       :alt="`Logo du ${tournament?.name}`"
       :src="tournament?.logo"
-      class="aspect-video w-screen text-clip"
+      class="max-w-screen aspect-video text-clip"
     />
     <p class="text-lg">
       {{ tournament?.validated_teams }}/{{ tournament?.maxTeam }} Équipes | Cashprize:


### PR DESCRIPTION
Ok, this one is really niche but IF a tournament has no image, it was taking all the screen in height.