### PR TITLE
Rework Tournament page

### DIFF
--- a/src/components/KnockoutMatchCard.vue
+++ b/src/components/KnockoutMatchCard.vue
@@ -8,14 +8,13 @@ defineProps<{
 </script>
 
 <template>
-  <div v-for="idx in teamPerMatch" :key="idx" class="flex justify-between bg-slate-700 p-2 text-xl" :class="{ 'bg-slate-900': status == 'ONGOING' }">
-    <!-- max-w-lg min-w-[22rem]-->
+  <div v-for="idx in teamPerMatch" :key="idx" class="flex items-center justify-between bg-slate-700 p-2 text-xl" :class="{ 'bg-slate-900': status == 'ONGOING' }">
     <div class="text-grey-500 truncate">
       {{ teams[idx - 1]?.name || "TBD" }}
-    </div> <div v-if="status == 'COMPLETED'" :class="teams[idx - 1]?.is_winner ? 'text-emerald-300' : 'text-white'" class="text-3xl font-black">
+    </div> <div v-if="status == 'COMPLETED'" :class="teams[idx - 1]?.is_winner ? 'text-emerald-300' : 'text-white'" class="text-2xl font-black">
       {{ teams[idx - 1]?.score }}
     </div>
-    <div v-else class="text-3xl font-black">
+    <div v-else class="text-2xl font-black">
       0
     </div>
   </div>

--- a/src/components/TournamentBrackets.vue
+++ b/src/components/TournamentBrackets.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import KnockoutMatchCard from '@/components/KnockoutMatchCard.vue';
+import { BracketType, type KnockoutMatch } from '@/models/bracket';
 import type { TournamentDeref } from '@/models/tournament';
 import { useTournamentStore } from '@/stores/tournament.store';
 
@@ -14,12 +16,13 @@ const {
   get_winner_matchs_per_round,
   get_looser_matchs,
   get_validated_team_by_id,
+  get_bracket_cols_count,
 } = tournamentStore;
 </script>
 
 <template>
   <section id="brackets">
-    <h1 v-if="props.tournament?.brackets?.length === 0" class="mt-6 text-center text-4xl">
+    <h1 v-if="props.tournament.brackets.length === 0" class="mt-6 text-center text-4xl">
       Les arbres ne sont pas disponibles.
     </h1>
     <div v-for="bracket in props.tournament.brackets" v-else :key="bracket.id">

--- a/src/components/TournamentBrackets.vue
+++ b/src/components/TournamentBrackets.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { TournamentDeref } from '@/models/tournament';
+import { useTournamentStore } from '@/stores/tournament.store';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+
+const tournamentStore = useTournamentStore();
+const {
+  get_col_style,
+  get_matchs_per_round,
+  knockout_match_results,
+  get_winner_matchs_per_round,
+  get_looser_matchs,
+  get_validated_team_by_id,
+} = tournamentStore;
+</script>
+
+<template>
+  <section id="brackets">
+    <h1 v-if="props.tournament?.brackets?.length === 0" class="mt-6 text-center text-4xl">
+      Les arbres ne sont pas disponibles.
+    </h1>
+    <div v-for="bracket in props.tournament.brackets" v-else :key="bracket.id">
+      <h1 class="title">
+        {{ bracket.name }}
+      </h1>
+      <div v-if="bracket.bracket_type === BracketType.SINGLE" :key="bracket.id" class="overflow-x-auto">
+        <div class="grid items-center gap-10" :style="get_col_style(bracket)">
+          <div v-for="(games, round_idx) in get_matchs_per_round(bracket.matchs)" :key="round_idx" class="flex h-full flex-col justify-around">
+            <div v-for="game in games" :key="game.id" class="m-2 divide-y">
+              <KnockoutMatchCard
+                :team-per-match="props.tournament.game.team_per_match"
+                :teams="knockout_match_results(game as KnockoutMatch)"
+                :status="game.status"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-if="bracket.bracket_type === BracketType.DOUBLE" :key="bracket.id" class="overflow-x-auto">
+        <div class="grid h-full items-center gap-10" :style="get_col_style(bracket)">
+          <div class="flex h-full flex-col justify-around">
+            <div v-for="game in get_winner_matchs_per_round(bracket.matchs, bracket.depth)" :key="game.id" class="m-2 divide-y">
+              <KnockoutMatchCard
+                :team-per-match="props.tournament.game.team_per_match"
+                :teams="knockout_match_results(game)"
+                :status="game.status"
+              />
+            </div>
+          </div>
+          <div v-for="col_idx in get_bracket_cols_count(bracket) - 2" :key="col_idx" class="flex h-full flex-col">
+            <div v-if="col_idx % 2" class="flex h-full flex-col justify-around">
+              <div v-for="game in get_winner_matchs_per_round(bracket.matchs, bracket.depth - (col_idx - 1) / 2 - 1)" :key="game.id" class="m-2 divide-y">
+                <KnockoutMatchCard
+                  :team-per-match="props.tournament.game.team_per_match"
+                  :teams="knockout_match_results(game)"
+                  :status="game.status"
+                />
+              </div>
+            </div>
+          </div>
+          <div v-if="bracket.winner !== null" class="w-40 bg-yellow-600 p-2">
+            <h1 class="text-bold text-center text-2xl">
+              Vainqueur
+            </h1>
+            <p class="text-center text-xl">
+              {{ get_validated_team_by_id(bracket.winner)?.name }}
+            </p>
+          </div>
+        </div>
+        <div class="grid items-center gap-10" :style="get_col_style(bracket)">
+          <div/>
+          <div v-for="(games, round_idx) in get_looser_matchs(bracket.matchs)" :key="round_idx" class="flex h-full flex-col justify-around">
+            <div v-for="game in games" :key="game.id" class="m-2 divide-y">
+              <KnockoutMatchCard
+                :team-per-match="props.tournament.game.team_per_match"
+                :teams="knockout_match_results(game)"
+                :status="game.status"
+              />
+            </div>
+          </div>
+          <div/>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/TournamentCard.vue
+++ b/src/components/TournamentCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { computed, onMounted } from 'vue';
-import type { Tournament } from '@/models/tournament';
+import type { Tournament, TournamentDeref } from '@/models/tournament';
 import { useTournamentStore } from '@/stores/tournament.store';
 
 const tournamentStore = useTournamentStore();
@@ -12,7 +12,23 @@ const props = defineProps<{
 
 const { getTournament } = tournamentStore;
 const { tournamentsList, eventsList } = storeToRefs(tournamentStore);
-const tournament = computed<Tournament | undefined>(() => tournamentsList.value[props.id]);
+const tournament = computed<Tournament | TournamentDeref | undefined>(() => tournamentsList.value[props.id]);
+const event_ongoing = computed(() => {
+  if (tournament.value === undefined) {
+    return false;
+  }
+
+  let event_id;
+  if (typeof tournament.value.event === 'number') {
+    event_id = tournament.value.event;
+  } else {
+    event_id = tournament.value.event.id;
+  }
+
+  const event = eventsList.value[event_id];
+
+  return event === undefined ? false : event.ongoing;
+});
 
 onMounted(async () => {
   await getTournament(props.id);
@@ -35,7 +51,7 @@ onMounted(async () => {
         Plus d'infos
       </router-link>
       <div
-        v-if="eventsList[tournament?.event.id || tournament?.event]?.ongoing"
+        v-if="event_ongoing"
         class="rounded bg-green-600 p-2 text-lg"
       >
         <router-link

--- a/src/components/TournamentCard.vue
+++ b/src/components/TournamentCard.vue
@@ -31,7 +31,7 @@ onMounted(async () => {
       {{ tournament?.cashprizes?.length !== 0 ? tournament?.cashprizes?.reduce((acc, val) => acc += Number(val), 0) + " €" : "À venir" }}
     </p>
     <div class="mb-3 flex w-[80%] justify-center gap-3 text-center">
-      <router-link :to="`tournament/${tournament?.id as number}`" class="rounded border-2 border-green-600 p-2 text-lg hover:border-green-500">
+      <router-link :to="`tournament/${tournament?.id as number}/info`" class="rounded border-2 border-green-600 p-2 text-lg hover:border-green-500">
         Plus d'infos
       </router-link>
       <div

--- a/src/components/TournamentCard.vue
+++ b/src/components/TournamentCard.vue
@@ -35,7 +35,7 @@ onMounted(async () => {
         Plus d'infos
       </router-link>
       <div
-        v-if="eventsList[tournament?.event as number]?.ongoing"
+        v-if="eventsList[tournament?.event.id || tournament?.event]?.ongoing"
         class="rounded bg-green-600 p-2 text-lg"
       >
         <router-link

--- a/src/components/TournamentCard.vue
+++ b/src/components/TournamentCard.vue
@@ -50,21 +50,16 @@ onMounted(async () => {
       <router-link :to="`tournament/${tournament?.id as number}/info`" class="rounded border-2 border-green-600 p-2 text-lg hover:border-green-500">
         Plus d'infos
       </router-link>
-      <div
-        v-if="event_ongoing"
-        class="rounded bg-green-600 p-2 text-lg"
+      <router-link
+        v-if="event_ongoing && Date.parse(tournament?.registration_close) > Date.now()"
+        :to="`tournament/${tournament?.id as number}/register`"
+        class="rounded bg-green-600 p-2 text-lg hover:bg-green-500"
       >
-        <router-link
-          v-if="Date.parse(tournament?.registration_close) > Date.now()"
-          :to="`tournament/${tournament?.id as number}/register`"
-          class="hover:bg-green-500"
-        >
-          S'inscrire
-        </router-link>
-        <button v-else type="button" class="opacity-60" disabled>
-          Inscriptions fermées
-        </button>
-      </div>
+        S'inscrire
+      </router-link>
+      <button v-else type="button" class="rounded bg-green-600 p-2 text-lg opacity-60" disabled>
+        Inscriptions fermées
+      </button>
     </div>
   </div>
   <!-- Placeholder when the tournament is not announced -->

--- a/src/components/TournamentGroups.vue
+++ b/src/components/TournamentGroups.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { computed, ref, toRef } from 'vue';
+import GroupTable from '@/components/GroupTable.vue';
+import type { Group } from '@/models/group';
+import type { TournamentDeref } from '@/models/tournament';
+import { useTournamentStore } from '@/stores/tournament.store';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+
+const tournament = toRef(props, 'tournament');
+const groups = tournament.value?.groups;
+
+const show_group_details = ref<number>(0);
+
+const tournamentStore = useTournamentStore();
+const {
+  getTournamentTeams,
+  get_group_by_id,
+  get_matchs_per_round,
+  get_validated_team_by_id,
+} = tournamentStore;
+
+getTournamentTeams();
+
+const group_details = computed<Group | undefined>(() => get_group_by_id(groups || [], show_group_details.value));
+
+const { tourney_teams } = storeToRefs(tournamentStore);
+</script>
+
+<template>
+  <section
+    id="groups"
+    :class="{ hidden: show_group_details !== 0 }"
+  >
+    <h1
+      v-if="groups?.length === 0"
+      class="mt-6 flex justify-center text-center text-4xl"
+    >
+      Les poules ne sont pas disponibles.
+    </h1>
+    <div
+      v-else
+      class="my-10 flex flex-1 flex-wrap justify-center gap-20"
+    >
+      <div
+        v-for="group in groups"
+        :key="group.id"
+        class="m-2 border-collapse border-slate-500 hover:ring-8 hover:ring-slate-500 lg:m-0 lg:w-2/5"
+        @click="show_group_details = group.id"
+        @keydown.enter="show_group_details = group.id"
+      >
+        <GroupTable
+          :teams="tourney_teams"
+          :group="group"
+        />
+      </div>
+    </div>
+  </section>
+
+  <section v-if="group_details !== undefined" id="group" :class="{ hidden: show_group_details === 0 }" class="flex flex-col p-4">
+    <nav class="my-5 flex justify-center gap-3">
+      <button type="button" class="w-full justify-center rounded-md bg-blue-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-blue-500 sm:ml-3 sm:w-auto" @click="show_group_details = 0">
+        <fa-awesome-icon icon="fa-solid fa-arrow-left"/> Retour
+      </button>
+      <h1 class="text-center text-3xl font-black">
+        {{ group_details?.name }}
+      </h1>
+    </nav>
+    <div class="flex flex-col justify-center gap-10 md:flex-row md:gap-3">
+      <div class="max-h-96 md:ml-10 md:w-1/2">
+        <GroupTable
+          :teams="tourney_teams"
+          :group="group_details"
+        />
+      </div>
+      <div class="flex flex-col-reverse md:w-1/2">
+        <div
+          v-for="matchs in get_matchs_per_round(group_details?.matchs ?? [])"
+          :key="matchs[0].id"
+        >
+          <h1 class="text-center text-3xl font-black">
+            Round {{ matchs[0].round_number }}
+          </h1>
+          <div class="gap-4">
+            <div v-for="game in matchs" :key="game.id">
+              <div v-if="game.teams.length == 2" class="flex justify-center">
+                <div class="mb-4 flex flex-1 justify-between divide-x overflow-hidden border-2 text-xl font-bold md:ml-10">
+                  <div class="w-full truncate p-3">
+                    {{ get_validated_team_by_id(game.teams[0])?.name || "TBD" }}
+                  </div>
+                  <div class="p-3">
+                    {{ game.score[game.teams[0]] }}
+                  </div>
+                </div>
+                <div class="mb-4 flex flex-1 divide-x overflow-hidden border-2 text-xl font-bold md:mr-10">
+                  <div class="p-3">
+                    {{ game.score[game.teams[1]] }}
+                  </div>
+                  <div class="w-full truncate p-3 text-right">
+                    {{ get_validated_team_by_id(game.teams[1])?.name || "TBD" }}
+                  </div>
+                </div>
+              </div>
+              <div v-else class="flex justify-center">
+                <div>
+                  <div class="mx-5 mb-4 flex flex-1 justify-between divide-x border-2 text-xl font-bold">
+                    <table>
+                      <tr>
+                        <th align="center" class="troncate border-separate border border-slate-500 bg-slate-200 p-4 text-black">
+                          Equipe
+                        </th>
+                        <th align="center" class="border-separate border border-slate-500 bg-slate-200 p-4 text-black">
+                          Score
+                        </th>
+                      </tr>
+                      <tr v-for="team_id in game.teams" :key="team_id">
+                        <td align="center" class="border-separate border border-slate-500 p-4">
+                          {{ get_validated_team_by_id(team_id)?.name || "TBD" }}
+                        </td>
+                        <td align="center" class="border-separate border border-slate-500 p-4">
+                          {{ game.score[team_id] }}
+                        </td>
+                      </tr>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/TournamentInfo.vue
+++ b/src/components/TournamentInfo.vue
@@ -10,126 +10,121 @@ const props = defineProps<{
   <section
     id="info"
     :style="{ backgroundImage: `url(${props.tournament?.logo})` }"
-    class="grid grid-rows-[min-content_1fr] bg-gray-500 bg-cover bg-center bg-blend-multiply"
+    class="grid grow grid-rows-[min-content_1fr] items-center bg-gray-500 bg-cover bg-center bg-blend-multiply"
   >
-    <h2 class="font mx-auto my-4 w-3/4 text-center text-3xl font-bold">
+    <h2 class="font mx-auto w-3/4 py-4 text-center text-3xl font-bold">
       {{ tournament?.description }}
     </h2>
 
     <div class="grid gap-7 md:grid-cols-3">
-      <div>
-        <div class="flex w-full flex-col items-center md:my-24">
-          <h3 class="mb-6 text-4xl">
-            Format
-          </h3>
-          <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
-            <desc>
-              Z tetromino with tournament format information
-            </desc>
-            <polygon points="0,0 8,0 8,4 12,4 12,8 4,8 4,4 0,4" fill="#fd5e96"/>
-            <rect fill="#d14d7b" x="0" y="3.5" width="4" height="0.5"/>
-            <rect fill="#d14d7b" x="4" y="7.5" width="8" height="0.5"/>
-            <text v-if="(tournament?.game as Game).players_per_team === 1" font-size="1" text-anchor="middle" x="4" y="2.25">
-              {{ tournament?.maxTeam }} joueurs
-            </text>
-            <text v-else font-size="1" text-anchor="middle" x="4" y="1.25">
-              <tspan>{{ tournament?.maxTeam }} équipes</tspan>
-              <tspan text-anchor="middle" x="4" y="2.75">
-                de {{ (tournament?.game as Game).players_per_team }} joueurs
-              </tspan>
-            </text>
-            <text font-size="1" text-anchor="middle" x="8" y="5.25">
-              {{ Number(tournament?.player_price_online) }}€ / joueur
-            </text>
-            <text font-size="1" text-anchor="middle" x="8" y="6.75">
-              {{ Number(tournament?.manager_price_online) }}€ / manager
-            </text>
-          </svg>
-        </div>
+      <div class="flex w-full flex-col items-center md:my-24">
+        <h3 class="mb-6 text-4xl">
+          Format
+        </h3>
+        <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
+          <desc>
+            Z tetromino with tournament format information
+          </desc>
+          <polygon points="0,0 8,0 8,4 12,4 12,8 4,8 4,4 0,4" fill="#fd5e96"/>
+          <rect fill="#d14d7b" x="0" y="3.5" width="4" height="0.5"/>
+          <rect fill="#d14d7b" x="4" y="7.5" width="8" height="0.5"/>
+          <text v-if="(tournament?.game as Game).players_per_team === 1" font-size="1" text-anchor="middle" x="4" y="2.25">
+            {{ tournament?.maxTeam }} joueurs
+          </text>
+          <text v-else font-size="1" text-anchor="middle" x="4" y="1.25">
+            <tspan>{{ tournament?.maxTeam }} équipes</tspan>
+            <tspan text-anchor="middle" x="4" y="2.75">
+              de {{ (tournament?.game as Game).players_per_team }} joueurs
+            </tspan>
+          </text>
+          <text font-size="1" text-anchor="middle" x="8" y="5.25">
+            {{ Number(tournament?.player_price_online) }}€ / joueur
+          </text>
+          <text font-size="1" text-anchor="middle" x="8" y="6.75">
+            {{ Number(tournament?.manager_price_online) }}€ / manager
+          </text>
+        </svg>
       </div>
 
-      <div>
-        <div class="flex w-full flex-col items-center">
-          <h3 class="mb-6 text-4xl">
-            Cashprize
-          </h3>
-          <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
-            <desc>
-              T tetromino with tournament cashprize information
-            </desc>
-            <polygon points="0,8 0,4 4,4 4,0 8,0 8,4 12,4 12,8" fill="#45cae0"/>
-            <rect x="0" y="7.5" width="12" height="0.5" fill="#0aadbf"/>
-            <text font-size="2" text-anchor="middle" x="6" y="2">
-              🥇
-            </text>
-            <text font-size="1" text-anchor="middle" x="6" y="3.25">
-              {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[0]) + " €" }}
-            </text>
-            <text font-size="2" text-anchor="middle" x="2" y="6">
-              🥈
-            </text>
-            <text font-size="1" text-anchor="middle" x="2" y="7.25">
-              {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[1]) + " €" }}
-            </text>
-            <text font-size="2" text-anchor="middle" x="10" y="6">
-              🥉
-            </text>
-            <text font-size="1" text-anchor="middle" x="10" y="7.25">
-              {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[2]) + " €" }}
-            </text>
-          </svg>
-        </div>
+      <div class="flex w-full flex-col items-center">
+        <h3 class="mb-6 text-4xl">
+          Cashprize
+        </h3>
+        <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
+          <desc>
+            T tetromino with tournament cashprize information
+          </desc>
+          <polygon points="0,8 0,4 4,4 4,0 8,0 8,4 12,4 12,8" fill="#45cae0"/>
+          <rect x="0" y="7.5" width="12" height="0.5" fill="#0aadbf"/>
+          <text font-size="2" text-anchor="middle" x="6" y="2">
+            🥇
+          </text>
+          <text font-size="1" text-anchor="middle" x="6" y="3.25">
+            {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[0]) + " €" }}
+          </text>
+          <text font-size="2" text-anchor="middle" x="2" y="6">
+            🥈
+          </text>
+          <text font-size="1" text-anchor="middle" x="2" y="7.25">
+            {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[1]) + " €" }}
+          </text>
+          <text font-size="2" text-anchor="middle" x="10" y="6">
+            🥉
+          </text>
+          <text font-size="1" text-anchor="middle" x="10" y="7.25">
+            {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[2]) + " €" }}
+          </text>
+        </svg>
       </div>
-      <div>
-        <div class="mb-12 flex w-full grow flex-col items-center md:my-24">
-          <h3 class="mb-6 text-4xl">
-            Casters
-          </h3>
-          <svg class="w-1/2 fill-white" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
-            <desc>
-              O tetromino with information on tournament's casters
-            </desc>
-            <rect x="0" y="0" width="8" height="8" fill="#B169BF"/>
-            <rect x="0" y="7.5" width="8" height="0.5" fill="#844A8F"/>
-            <g v-if="tournament?.casters.length === 0">
-              <text font-size="1">
-                <tspan x="4" y="3.5" text-anchor="middle">Aucun caster</tspan>
-                <tspan x="4" y="5" text-anchor="middle">pour ce tournoi</tspan>
-              </text>
-            </g>
-            <g v-else-if="tournament?.casters.length === 1">
-              <a :href="tournament?.casters[0].url">
-                <g v-if="tournament?.casters[0].image">
-                  <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
-                    {{ tournament?.casters[0].name }}
-                  </text>
-                  <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
-                  <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5" y="4.5"/>
-                </g>
-                <text v-else font-size="1" textLength="7.5" text-anchor="middle" x="4" y="4.25">
-                  {{ tournament?.casters[0].name }}
-                </text>
-              </a>
-            </g>
-            <g v-else-if="tournament?.casters.length === 2">
-              <a :href="tournament?.casters[0].url">
+
+      <div class="mb-12 flex w-full grow flex-col items-center md:my-24">
+        <h3 class="mb-6 text-4xl">
+          Casters
+        </h3>
+        <svg class="w-1/2 fill-white" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+          <desc>
+            O tetromino with information on tournament's casters
+          </desc>
+          <rect x="0" y="0" width="8" height="8" fill="#B169BF"/>
+          <rect x="0" y="7.5" width="8" height="0.5" fill="#844A8F"/>
+          <g v-if="tournament?.casters.length === 0">
+            <text font-size="1">
+              <tspan x="4" y="3.5" text-anchor="middle">Aucun caster</tspan>
+              <tspan x="4" y="5" text-anchor="middle">pour ce tournoi</tspan>
+            </text>
+          </g>
+          <g v-else-if="tournament?.casters.length === 1">
+            <a :href="tournament?.casters[0].url">
+              <g v-if="tournament?.casters[0].image">
                 <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
                   {{ tournament?.casters[0].name }}
                 </text>
                 <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
-                <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5"/>
-              </a>
-              <a :href="tournament?.casters[1].url">
-                <text font-size="1" textLength="3.5" text-anchor="middle" x="6" y="6.25">
-                  {{ tournament?.casters[1].name }}
-                </text>
-                <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
-                <image :href="tournament?.casters[1].image" class="overflow-clip" width="3.5" height="3" y="4.5"/>
-              </a>
-              <text font-size="1" text-anchor="middle" x="4" y="4.25">&</text>
-            </g>
-          </svg>
-        </div>
+                <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5" y="4.5"/>
+              </g>
+              <text v-else font-size="1" textLength="7.5" text-anchor="middle" x="4" y="4.25">
+                {{ tournament?.casters[0].name }}
+              </text>
+            </a>
+          </g>
+          <g v-else-if="tournament?.casters.length === 2">
+            <a :href="tournament?.casters[0].url">
+              <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
+                {{ tournament?.casters[0].name }}
+              </text>
+              <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
+              <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5"/>
+            </a>
+            <a :href="tournament?.casters[1].url">
+              <text font-size="1" textLength="3.5" text-anchor="middle" x="6" y="6.25">
+                {{ tournament?.casters[1].name }}
+              </text>
+              <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
+              <image :href="tournament?.casters[1].image" class="overflow-clip" width="3.5" height="3" y="4.5"/>
+            </a>
+            <text font-size="1" text-anchor="middle" x="4" y="4.25">&</text>
+          </g>
+        </svg>
       </div>
     </div>
   </section>

--- a/src/components/TournamentInfo.vue
+++ b/src/components/TournamentInfo.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import type { TournamentDeref } from '@/models/tournament';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+</script>
+
+<template>
+  <section
+    id="info"
+    :style="{ backgroundImage: `url(${props.tournament?.logo})` }"
+    class="grid grid-rows-[min-content_1fr] bg-gray-500 bg-cover bg-center bg-blend-multiply"
+  >
+    <h2 class="font mx-auto my-4 w-3/4 text-center text-3xl font-bold">
+      {{ tournament?.description }}
+    </h2>
+
+    <div class="grid gap-7 md:grid-cols-3">
+      <div>
+        <div class="flex w-full flex-col items-center md:my-24">
+          <h3 class="mb-6 text-4xl">
+            Format
+          </h3>
+          <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
+            <desc>
+              Z tetromino with tournament format information
+            </desc>
+            <polygon points="0,0 8,0 8,4 12,4 12,8 4,8 4,4 0,4" fill="#fd5e96"/>
+            <rect fill="#d14d7b" x="0" y="3.5" width="4" height="0.5"/>
+            <rect fill="#d14d7b" x="4" y="7.5" width="8" height="0.5"/>
+            <text v-if="(tournament?.game as Game).players_per_team === 1" font-size="1" text-anchor="middle" x="4" y="2.25">
+              {{ tournament?.maxTeam }} joueurs
+            </text>
+            <text v-else font-size="1" text-anchor="middle" x="4" y="1.25">
+              <tspan>{{ tournament?.maxTeam }} équipes</tspan>
+              <tspan text-anchor="middle" x="4" y="2.75">
+                de {{ (tournament?.game as Game).players_per_team }} joueurs
+              </tspan>
+            </text>
+            <text font-size="1" text-anchor="middle" x="8" y="5.25">
+              {{ Number(tournament?.player_price_online) }}€ / joueur
+            </text>
+            <text font-size="1" text-anchor="middle" x="8" y="6.75">
+              {{ Number(tournament?.manager_price_online) }}€ / manager
+            </text>
+          </svg>
+        </div>
+      </div>
+
+      <div>
+        <div class="flex w-full flex-col items-center">
+          <h3 class="mb-6 text-4xl">
+            Cashprize
+          </h3>
+          <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
+            <desc>
+              T tetromino with tournament cashprize information
+            </desc>
+            <polygon points="0,8 0,4 4,4 4,0 8,0 8,4 12,4 12,8" fill="#45cae0"/>
+            <rect x="0" y="7.5" width="12" height="0.5" fill="#0aadbf"/>
+            <text font-size="2" text-anchor="middle" x="6" y="2">
+              🥇
+            </text>
+            <text font-size="1" text-anchor="middle" x="6" y="3.25">
+              {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[0]) + " €" }}
+            </text>
+            <text font-size="2" text-anchor="middle" x="2" y="6">
+              🥈
+            </text>
+            <text font-size="1" text-anchor="middle" x="2" y="7.25">
+              {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[1]) + " €" }}
+            </text>
+            <text font-size="2" text-anchor="middle" x="10" y="6">
+              🥉
+            </text>
+            <text font-size="1" text-anchor="middle" x="10" y="7.25">
+              {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[2]) + " €" }}
+            </text>
+          </svg>
+        </div>
+      </div>
+      <div>
+        <div class="mb-12 flex w-full grow flex-col items-center md:my-24">
+          <h3 class="mb-6 text-4xl">
+            Casters
+          </h3>
+          <svg class="w-1/2 fill-white" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
+            <desc>
+              O tetromino with information on tournament's casters
+            </desc>
+            <rect x="0" y="0" width="8" height="8" fill="#B169BF"/>
+            <rect x="0" y="7.5" width="8" height="0.5" fill="#844A8F"/>
+            <g v-if="tournament?.casters.length === 0">
+              <text font-size="1">
+                <tspan x="4" y="3.5" text-anchor="middle">Aucun caster</tspan>
+                <tspan x="4" y="5" text-anchor="middle">pour ce tournoi</tspan>
+              </text>
+            </g>
+            <g v-else-if="tournament?.casters.length === 1">
+              <a :href="tournament?.casters[0].url">
+                <g v-if="tournament?.casters[0].image">
+                  <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
+                    {{ tournament?.casters[0].name }}
+                  </text>
+                  <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
+                  <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5" y="4.5"/>
+                </g>
+                <text v-else font-size="1" textLength="7.5" text-anchor="middle" x="4" y="4.25">
+                  {{ tournament?.casters[0].name }}
+                </text>
+              </a>
+            </g>
+            <g v-else-if="tournament?.casters.length === 2">
+              <a :href="tournament?.casters[0].url">
+                <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
+                  {{ tournament?.casters[0].name }}
+                </text>
+                <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
+                <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5"/>
+              </a>
+              <a :href="tournament?.casters[1].url">
+                <text font-size="1" textLength="3.5" text-anchor="middle" x="6" y="6.25">
+                  {{ tournament?.casters[1].name }}
+                </text>
+                <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
+                <image :href="tournament?.casters[1].image" class="overflow-clip" width="3.5" height="3" y="4.5"/>
+              </a>
+              <text font-size="1" text-anchor="middle" x="4" y="4.25">&</text>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/TournamentInfo.vue
+++ b/src/components/TournamentInfo.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Game } from '@/models/game';
 import type { TournamentDeref } from '@/models/tournament';
 
 const props = defineProps<{

--- a/src/components/TournamentPlanning.vue
+++ b/src/components/TournamentPlanning.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import Content from '@/components/Content.vue';
 import type { TournamentDeref } from '@/models/tournament';
 import { useContentStore } from '@/stores/content.store';
 

--- a/src/components/TournamentPlanning.vue
+++ b/src/components/TournamentPlanning.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { TournamentDeref } from '@/models/tournament';
+import { useContentStore } from '@/stores/content.store';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+
+const { getContent } = useContentStore();
+</script>
+
+<template>
+  <section id="planning">
+    <div class="m-1 flex justify-center rounded bg-cyan-900 p-2">
+      Les plannings peuvent varier en fonction de l'avancement des tournois et sont donnés à titre indicatif.
+    </div>
+    <div v-if="!getContent(props.tournament?.planning)" class="flex justify-center">
+      Le planning n'est pas encore disponible, revenez plus tard !
+    </div>
+    <div class="flex justify-center">
+      <div class="m-2 overflow-auto overscroll-y-auto">
+        <content :name="props.tournament?.planning"/>
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/components/TournamentRules.vue
+++ b/src/components/TournamentRules.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { TournamentDeref } from '@/models/tournament';
+import { useContentStore } from '@/stores/content.store';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+
+const { md } = useContentStore();
+</script>
+
+<template>
+  <section id="rules">
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div class="mx-auto my-4 w-[min(1080px,90%)] text-justify" v-html="md.render(props.tournament?.rules)"/>
+  </section>
+</template>

--- a/src/components/TournamentSwiss.vue
+++ b/src/components/TournamentSwiss.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import SwissRoundTable from '@/components/SwissRoundTable.vue';
+import type { TournamentDeref } from '@/models/tournament';
+import { useTournamentStore } from '@/stores/tournament.store';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+
+const tournamentStore = useTournamentStore();
+const { swiss_match_results } = tournamentStore;
+</script>
+
+<template>
+  <section class="mt-6 flex h-full justify-center">
+    <div v-for="swiss in props.tournament?.swissRounds" :key="swiss.id" class="mx-3 overflow-x-auto">
+      <SwissRoundTable
+        :rounds="swiss_match_results(swiss.matchs)"
+        :team-per-match="props.tournament?.game.team_per_match"
+        :round-count="2 * swiss.min_score - 1"
+      />
+    </div>
+  </section>
+</template>

--- a/src/components/TournamentTeams.vue
+++ b/src/components/TournamentTeams.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import TeamCard from '@/components/TeamCard.vue';
+import type { TournamentDeref } from '@/models/tournament';
+import { useTournamentStore } from '@/stores/tournament.store';
+
+const props = defineProps<{
+  tournament: TournamentDeref;
+}>();
+
+const tournamentStore = useTournamentStore();
+const { getTournamentTeams } = tournamentStore;
+
+getTournamentTeams();
+
+const { tourney_teams } = storeToRefs(tournamentStore);
+</script>
+
+<template>
+  <section id="teams">
+    <h1 v-if="props.tournament?.teams.length === 0" class="mt-6 text-center text-4xl">
+      Aucune équipe inscrite
+    </h1>
+    <div v-if="tourney_teams?.validated_teams.length > 0">
+      <h1 class="title">
+        Équipes validées
+      </h1>
+      <div class="grid gap-4 p-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <TeamCard
+          v-for="team in tourney_teams.validated_teams"
+          :key="team.id"
+          :team="team"
+        />
+      </div>
+    </div>
+    <div v-if="tourney_teams?.non_validated_teams.length > 0">
+      <h1 class="title">
+        Équipes en cours de validation
+      </h1>
+      <div class="grid gap-4 p-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <TeamCard
+          v-for="team in tourney_teams.non_validated_teams"
+          :key="team.id"
+          :team="team"
+        />
+      </div>
+    </div>
+  </section>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,11 @@
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
-  faArrowLeft,
+  faAngleDown,
+  faAngleUp, faArrowLeft,
   faArrowsRotate,
-  faBolt,
-  faCheck,
-  faChevronDown,
-  faChevronUp,
-  faCircle,
-  faCircleCheck,
+  faBolt, faCheck,
+  faChevronDown, faChevronUp,
+  faCircle, faCircleCheck,
   faCirclePlus,
   faClock,
   faCrown,
@@ -62,6 +60,8 @@ library.add(
   faPizzaSlice,
   faXmark,
   faCheck,
+  faAngleDown,
+  faAngleUp,
 );
 
 axios.defaults.baseURL = import.meta.env.VITE_API_URL;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -53,9 +53,39 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/Register.vue'),
   },
   {
-    path: '/tournament/:id(\\d+)/:section(\\w+)*',
+    path: '/tournament/:id(\\d+)',
     component: () => import('@/views/TournamentDetail.vue'),
-    props: (route) => ({ id: Number(route.params.id), selectedSection: route.params.section }),
+    props: (route) => ({ id: Number(route.params.id) }),
+    children: [
+      {
+        path: 'info',
+        component: () => import('@/components/TournamentInfo.vue'),
+      },
+      {
+        path: 'teams',
+        component: () => import('@/components/TournamentTeams.vue'),
+      },
+      {
+        path: 'groups',
+        component: () => import('@/components/TournamentGroups.vue'),
+      },
+      {
+        path: 'swiss',
+        component: () => import('@/components/TournamentSwiss.vue'),
+      },
+      {
+        path: 'brackets',
+        component: () => import('@/components/TournamentBrackets.vue'),
+      },
+      {
+        path: 'planning',
+        component: () => import('@/components/TournamentPlanning.vue'),
+      },
+      {
+        path: 'rules',
+        component: () => import('@/components/TournamentRules.vue'),
+      },
+    ],
   },
   {
     path: '/tournament/:id(\\d+)/team/:teamId(\\d+)',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -58,6 +58,10 @@ const routes: RouteRecordRaw[] = [
     props: (route) => ({ id: Number(route.params.id) }),
     children: [
       {
+        path: '',
+        redirect: (to) => `${to.fullPath}/info`,
+      },
+      {
         path: 'info',
         component: () => import('@/components/TournamentInfo.vue'),
       },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -53,9 +53,9 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/Register.vue'),
   },
   {
-    path: '/tournament/:id(\\d+)',
+    path: '/tournament/:id(\\d+)/:section(\\w+)*',
     component: () => import('@/views/TournamentDetail.vue'),
-    props: (route) => ({ id: Number(route.params.id), section: route.query }),
+    props: (route) => ({ id: Number(route.params.id), selectedSection: route.params.section }),
   },
   {
     path: '/tournament/:id(\\d+)/team/:teamId(\\d+)',

--- a/src/views/Me.vue
+++ b/src/views/Me.vue
@@ -351,7 +351,7 @@ const openScoreModal = () => {
             <div class="hidden flex-col md:block">
               <router-link
                 class="mt-auto text-zinc-400"
-                :to="`/tournament/${inscription[1].team.tournament.id }?s=rules`"
+                :to="`/tournament/${inscription[1].team.tournament.id }/rules`"
               >
                 Règlement du tournoi
               </router-link>
@@ -412,7 +412,7 @@ const openScoreModal = () => {
             <div class="hidden flex-col md:block">
               <router-link
                 class="mt-auto text-zinc-400"
-                :to="`/tournament/${inscription[1].team.tournament.id }?s=rules`"
+                :to="`/tournament/${inscription[1].team.tournament.id }/rules`"
               >
                 Règlement du tournoi
               </router-link>

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -77,6 +77,7 @@ try {
               :to="key"
               :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': key === selected_section }"
               class="text-xl"
+              @click="open_dropdown = false"
             >
               {{ section.title }}
             </router-link>

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import type { TournamentDeref } from '@/models/tournament';
 import { useTournamentStore } from '@/stores/tournament.store';
 
 const props = defineProps<{
@@ -18,15 +19,14 @@ const dropdown_icon = computed(() => (open_dropdown.value ? 'angle-up' : 'angle-
 interface TournamentDetailSection {
   title: string;
   is_available: boolean;
-  is_selected: boolean;
 }
 
 const sections = computed<Record<string, TournamentDetailSection>>(() => ({
   info: { title: 'Informations', is_available: true },
   teams: { title: 'Équipes', is_available: true },
-  groups: { title: 'Poules', is_available: tournament.value?.groups.length > 0 || false },
-  swiss: { title: 'Système Suisse', is_available: tournament.value?.swissRounds.length > 0 || false },
-  brackets: { title: 'Arbres', is_available: tournament.value?.brackets.length > 0 || false },
+  groups: { title: 'Poules', is_available: (tournament.value as TournamentDeref)?.groups.length > 0 || false },
+  swiss: { title: 'Système Suisse', is_available: (tournament.value as TournamentDeref)?.swissRounds.length > 0 || false },
+  brackets: { title: 'Arbres', is_available: (tournament.value as TournamentDeref)?.brackets.length > 0 || false },
   planning: { title: 'Planning', is_available: true },
   rules: { title: 'Règlement', is_available: true },
 }));
@@ -77,7 +77,6 @@ try {
               :to="key"
               :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': key === selected_section }"
               class="text-xl"
-              @click="selected_section = key; open_dropdown = false"
             >
               {{ section.title }}
             </router-link>

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -13,8 +13,8 @@ const tournamentStore = useTournamentStore();
 const { getTournamentFull } = tournamentStore;
 const { tournament } = storeToRefs(tournamentStore);
 
-// const open_drop = ref(false);
-// const drop_label = ref('Informations');
+const open_dropdown = ref(false);
+const dropdown_icon = computed(() => (open_dropdown.value ? 'angle-up' : 'angle-down'));
 
 interface TournamentDetailSection {
   title: string;
@@ -50,15 +50,30 @@ try {
         {{ tournament?.name }}
       </div>
 
-      <nav class="mt-2 flex justify-center bg-gray-500 py-4 ">
-        <div class="flex w-2/3 justify-between xl:w-3/5">
+      <nav class="mt-2 flex justify-center gap-16 bg-gray-500 py-4">
+        <button
+          type="button"
+          class="text-xl underline decoration-[#63d1ff] decoration-4 underline-offset-8 md:hidden"
+          @click="open_dropdown = !open_dropdown"
+        >
+          {{ sections[selected_section].title }}
+          <fa-awesome-icon
+            class="absolute mx-2 my-[0.6rem]"
+            :icon="['fas', dropdown_icon]"
+            size="2xs"
+          />
+        </button>
+        <div
+          :class="{ 'flex border-y-2 border-white': open_dropdown, hidden: !open_dropdown }"
+          class="absolute z-10 max-h-[60vh] w-screen translate-y-10 flex-col items-center gap-2 overflow-scroll bg-gray-500 py-3 md:static md:z-0 md:flex md:w-auto md:translate-y-0 md:flex-row md:gap-10 md:overflow-visible md:py-0"
+        >
           <template v-for="(section, key) in sections" :key="key">
             <router-link
               v-if="section.is_available"
               :to="key"
               :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': key === selected_section }"
               class="text-xl"
-              @click="selected_section = key"
+              @click="selected_section = key; open_dropdown = false"
             >
               {{ section.title }}
             </router-link>

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -1,573 +1,114 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
-import { reactive, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
-import Content from '@/components/Content.vue';
-import GroupTable from '@/components/GroupTable.vue';
-import KnockoutMatchCard from '@/components/KnockoutMatchCard.vue';
-import SwissRoundTable from '@/components/SwissRoundTable.vue';
-import TeamCard from '@/components/TeamCard.vue';
-import {
-  BracketSet, BracketType, type KnockoutMatch,
-} from '@/models/bracket';
-import type { Game } from '@/models/game';
-import type { Group } from '@/models/group';
-import type { SwissMatch } from '@/models/swiss';
-import { useContentStore } from '@/stores/content.store';
-import { groupBy, useTournamentStore } from '@/stores/tournament.store';
+import TournamentBrackets from '@/components/TournamentBrackets.vue';
+import TournamentGroups from '@/components/TournamentGroups.vue';
+import TournamentInfo from '@/components/TournamentInfo.vue';
+import TournamentPlanning from '@/components/TournamentPlanning.vue';
+import TournamentRules from '@/components/TournamentRules.vue';
+import TournamentSwiss from '@/components/TournamentSwiss.vue';
+import TournamentTeams from '@/components/TournamentTeams.vue';
+import { useTournamentStore } from '@/stores/tournament.store';
 
 const props = defineProps<{
   id: number;
-  section?: { s: string };
+  selectedSection?: string;
 }>();
 
-const { md, getContent } = useContentStore();
-
 const tournamentStore = useTournamentStore();
-const {
-  getTournamentFull, getTournamentTeams, get_matchs_per_round, is_winning_team,
-  get_validated_team_by_id, get_col_style, get_bracket_cols_count, get_group_by_id, get_winner_matchs_per_round,
-} = tournamentStore;
-const { tournament, tourney_teams } = storeToRefs(tournamentStore);
-const open_drop = ref(false);
-const drop_label = ref('Informations');
-const trans = ref('translateX(0vw)');
-const show_detail_group = ref<number>(0);
-const sections = reactive<Record<string, [boolean, number]>>({
-  info: [false, 0],
-  teams: [false, 1],
-  groups: [false, 2],
-  brackets: [false, 3],
-  planning: [false, 4],
-  rules: [false, 5],
-});
+const { getTournamentFull } = tournamentStore;
+const { tournament } = storeToRefs(tournamentStore);
 
-const select_tag = (e: Event) => {
+// const open_drop = ref(false);
+// const drop_label = ref('Informations');
+
+interface TournamentDetailSection {
+  title: string;
+  is_available: boolean;
+  is_selected: boolean;
+}
+
+const selected_section = ref<string>('info');
+
+const sections = computed<Record<string, TournamentDetailSection[]>>(() => ({
+  info: { title: 'Informations', is_available: true },
+  teams: { title: 'Équipes', is_available: true },
+  groups: { title: 'Poules', is_available: tournament.value?.groups.length > 0 || false },
+  swiss: { title: 'Système Suisse', is_available: tournament.value?.swissRounds.length > 0 || false },
+  knockouts: { title: 'Arbres', is_available: tournament.value?.brackets.length > 0 || false },
+  planning: { title: 'Planning', is_available: true },
+  rules: { title: 'Règlement', is_available: true },
+}));
+
+const select_section = (e: Event) => {
   const target = e.target as HTMLInputElement;
-  open_drop.value = false;
-  drop_label.value = target.innerHTML;
-  trans.value = `translateX(calc(-100vw * ${sections[target.id][1]}))`;
-  Object.keys(sections).forEach((k) => {
-    sections[k][0] = false;
-  });
-  sections[target.id][0] = true;
-};
-
-const get_looser_matchs = (matchs: KnockoutMatch[]) => {
-  const looser_matchs = matchs.filter((match) => match.bracket_set === BracketSet.LOOSER);
-  const round_matchs = groupBy(looser_matchs, 'round_number');
-  return Object.values(round_matchs).reverse();
-};
-
-const knockout_match_results = (match: KnockoutMatch) => {
-  const match_results = [] as Record<string, string | number | boolean | undefined>[];
-  match.teams.forEach((team) => {
-    const data = {} as Record<string, string | number | boolean | undefined>;
-    data.name = get_validated_team_by_id(team)?.name;
-    data.score = match.score[team];
-    data.is_winner = is_winning_team(match, team);
-    match_results.push(data);
-  });
-
-  return match_results;
-};
-
-const swiss_match_results = (matchs : SwissMatch[]) => {
-  const round_matchs = groupBy(matchs, 'round_number');
-  const res = {} as Record<string, Record<string, string | Record<string, string | number | boolean | undefined>[]>[]>;
-  Object.entries(round_matchs).forEach(([round, roundMatchs]) => {
-    res[round] = [] as Record<string, string | Record<string, string | number | boolean | undefined>[]>[];
-    roundMatchs.forEach((match) => {
-      const tmp = {} as { teams: Record<string, string | number | boolean | undefined>[]; status: string };
-      tmp.teams = [];
-      tmp.status = match.status;
-      match.teams.forEach((team) => {
-        const data = {} as { name: string | undefined; score: number; is_winner: boolean };
-        data.name = get_validated_team_by_id(team)?.name;
-        data.score = match.score[team];
-        data.is_winner = is_winning_team(match, team);
-        tmp.teams.push(data);
-      });
-      res[round].push(tmp);
-    });
-  });
-
-  return res;
+  selected_section.value = target.id;
+  // Object.keys(sections).forEach((s) => {
+  //   sections[s].is_selected = false;
+  // });
+  // sections[target.id].is_selected = true;
 };
 
 const router = useRouter();
-try {
-  await getTournamentFull(props.id);
-  getTournamentTeams();
-} catch (err: unknown) {
-  router.go(-1);
+
+if (props.selectedSection !== '') {
+  if (!(props.selectedSection in sections.value)) {
+    router.go(-1);
+  }
+
+  selected_section.value = props.selectedSection;
+  // sections[props.selectedSection].is_selected = true;
 }
 
-if (props.section !== undefined && props.section.s in sections) {
-  sections[props.section.s][0] = true;
-  drop_label.value = props.section.s;
-  trans.value = `translateX(calc(-100vw * ${sections[props.section.s][1]}`;
-} else {
-  sections.info[0] = true;
+try {
+  await getTournamentFull(props.id);
+} catch (err: unknown) {
+  router.go(-1);
 }
 </script>
 
 <template>
-  <div v-if="tournament?.is_announced" class="flex min-h-[calc(100vh_-_6rem)] flex-col items-center">
+  <div v-if="tournament?.is_announced" class="min-h-[calc(100vh_-_6rem)]">
     <div class="sticky top-24 min-w-full bg-[#2c292d]">
       <div class="text-center text-6xl font-bold text-white">
         {{ tournament?.name }}
       </div>
 
-      <nav class="mt-2 flex justify-center bg-gray-500 py-4">
-        <button
-          :class="{ 'after:translate-x-[5px] after:rotate-90 ': open_drop, 'after:-rotate-90': !open_drop }"
-          class="text-xl after:inline-block after:w-4 after:origin-center after:content-['\2039'] md:hidden"
-          type="button"
-          @click="open_drop = !open_drop"
-        >
-          {{ drop_label }}
-        </button> <!-- id="dropdown-btn"--> <!--@click="switch_tag"-->
-        <div
-          class="dropGrow absolute z-10 w-screen translate-y-10 flex-col items-center bg-gray-500 md:static md:z-0 md:flex md:w-2/3 md:translate-y-0 md:flex-row md:justify-between xl:w-1/2"
-          :class="{ 'flex border-t-2 border-white': open_drop, hidden: !open_drop }"
-        >
-          <!--id="dropdown"-->
-          <button
-            id="info"
-            :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': sections.info[0] }"
-            class="my-2 text-xl md:my-0"
-            type="button"
-            @click="select_tag"
-          >
-            Informations
-          </button> <!--href="#infos"-->
-          <button
-            id="teams"
-            :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': sections.teams[0] }"
-            class="my-2 text-xl md:my-0"
-            type="button"
-            @click="select_tag"
-          >
-            Équipes
-          </button> <!--href="#teams"-->
-          <button
-            id="groups"
-            type="button"
-            class="my-2 text-xl md:my-0"
-            :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': sections.groups[0] }"
-            @click="select_tag"
-          >
-            Poules
-          </button> <!--href="#groups"-->
-          <button
-            id="brackets"
-            :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': sections.brackets[0] }"
-            class="my-2 text-xl md:my-0"
-            type="button"
-            @click="select_tag"
-          >
-            Arbres
-          </button> <!--href="#brackets"-->
-          <button
-            id="planning"
-            :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': sections.planning[0] }"
-            class="my-2 text-xl md:my-0"
-            type="button"
-            @click="select_tag"
-          >
-            Planning
-          </button> <!--href="#planning"-->
-          <button
-            id="rules"
-            :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': sections.rules[0] }"
-            class="my-2 text-xl md:my-0"
-            type="button"
-            @click="select_tag"
-          >
-            Règlement
-          </button> <!--href="#rules"-->
+      <nav class="mt-2 flex justify-center bg-gray-500 py-4 ">
+        <div class="flex w-2/3 justify-between xl:w-1/2">
+          <template v-for="(section, key) in sections" :key="key">
+            <button
+              v-if="section.is_available"
+              :id="key"
+              :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': key === selected_section }"
+              type="button"
+              class="text-xl"
+              @click="select_section"
+            >
+              {{ section.title }}
+            </button>
+          </template>
         </div>
       </nav>
     </div>
+    {{ sections }}
 
-    <section
-      id="infos"
-      :style="{ backgroundImage: `url(${tournament?.logo})` }"
-      class="grid grid-rows-[min-content_1fr] bg-gray-500 bg-cover bg-center bg-blend-multiply"
-      :class="{ hidden: !sections.info[0] }"
-    >
-      <h2 class="font mx-auto my-4 w-3/4 text-center text-3xl font-bold">
-        {{ tournament?.description }}
-      </h2>
+    <TournamentInfo v-if="selected_section === 'info'" :tournament="tournament"/>
 
-      <div class="grid gap-7 md:grid-cols-3">
-        <div>
-          <div class="flex w-full flex-col items-center md:my-24">
-            <h3 class="mb-6 text-4xl">
-              Format
-            </h3>
-            <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
-              <desc>
-                Z tetromino with tournament format information
-              </desc>
-              <polygon points="0,0 8,0 8,4 12,4 12,8 4,8 4,4 0,4" fill="#fd5e96"/>
-              <rect fill="#d14d7b" x="0" y="3.5" width="4" height="0.5"/>
-              <rect fill="#d14d7b" x="4" y="7.5" width="8" height="0.5"/>
-              <text v-if="(tournament?.game as Game).players_per_team === 1" font-size="1" text-anchor="middle" x="4" y="2.25">
-                {{ tournament?.maxTeam }} joueurs
-              </text>
-              <text v-else font-size="1" text-anchor="middle" x="4" y="1.25">
-                <tspan>{{ tournament?.maxTeam }} équipes</tspan>
-                <tspan text-anchor="middle" x="4" y="2.75">
-                  de {{ (tournament?.game as Game).players_per_team }} joueurs
-                </tspan>
-              </text>
-              <text font-size="1" text-anchor="middle" x="8" y="5.25">
-                {{ Number(tournament?.player_price_online) }}€ / joueur
-              </text>
-              <text font-size="1" text-anchor="middle" x="8" y="6.75">
-                {{ Number(tournament?.manager_price_online) }}€ / manager
-              </text>
-            </svg>
-          </div>
-        </div>
+    <TournamentTeams v-if="selected_section === 'teams'" :tournament="tournament"/>
 
-        <div>
-          <div class="flex w-full flex-col items-center">
-            <h3 class="mb-6 text-4xl">
-              Cashprize
-            </h3>
-            <svg class="w-2/3 fill-white" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg">
-              <desc>
-                T tetromino with tournament cashprize information
-              </desc>
-              <polygon points="0,8 0,4 4,4 4,0 8,0 8,4 12,4 12,8" fill="#45cae0"/>
-              <rect x="0" y="7.5" width="12" height="0.5" fill="#0aadbf"/>
-              <text font-size="2" text-anchor="middle" x="6" y="2">
-                🥇
-              </text>
-              <text font-size="1" text-anchor="middle" x="6" y="3.25">
-                {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[0]) + " €" }}
-              </text>
-              <text font-size="2" text-anchor="middle" x="2" y="6">
-                🥈
-              </text>
-              <text font-size="1" text-anchor="middle" x="2" y="7.25">
-                {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[1]) + " €" }}
-              </text>
-              <text font-size="2" text-anchor="middle" x="10" y="6">
-                🥉
-              </text>
-              <text font-size="1" text-anchor="middle" x="10" y="7.25">
-                {{ tournament?.cashprizes.length === 0 ? "À venir" : Number(tournament?.cashprizes[2]) + " €" }}
-              </text>
-            </svg>
-          </div>
-        </div>
-        <div>
-          <div class="mb-12 flex w-full grow flex-col items-center md:my-24">
-            <h3 class="mb-6 text-4xl">
-              Casters
-            </h3>
-            <svg class="w-1/2 fill-white" viewBox="0 0 8 8" xmlns="http://www.w3.org/2000/svg">
-              <desc>
-                O tetromino with information on tournament's casters
-              </desc>
-              <rect x="0" y="0" width="8" height="8" fill="#B169BF"/>
-              <rect x="0" y="7.5" width="8" height="0.5" fill="#844A8F"/>
-              <g v-if="tournament?.casters.length === 0">
-                <text font-size="1">
-                  <tspan x="4" y="3.5" text-anchor="middle">Aucun caster</tspan>
-                  <tspan x="4" y="5" text-anchor="middle">pour ce tournoi</tspan>
-                </text>
-              </g>
-              <g v-else-if="tournament?.casters.length === 1">
-                <a :href="tournament?.casters[0].url">
-                  <g v-if="tournament?.casters[0].image">
-                    <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
-                      {{ tournament?.casters[0].name }}
-                    </text>
-                    <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
-                    <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5" y="4.5"/>
-                  </g>
-                  <text v-else font-size="1" textLength="7.5" text-anchor="middle" x="4" y="4.25">
-                    {{ tournament?.casters[0].name }}
-                  </text>
-                </a>
-              </g>
-              <g v-else-if="tournament?.casters.length === 2">
-                <a :href="tournament?.casters[0].url">
-                  <text font-size="1" textLength="3.5" text-anchor="middle" x="2" y="2.25">
-                    {{ tournament?.casters[0].name }}
-                  </text>
-                  <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
-                  <image :href="tournament?.casters[0].image" class="overflow-clip" width="3.5" height="3" x="4.5"/>
-                </a>
-                <a :href="tournament?.casters[1].url">
-                  <text font-size="1" textLength="3.5" text-anchor="middle" x="6" y="6.25">
-                    {{ tournament?.casters[1].name }}
-                  </text>
-                  <!-- eslint-disable-next-line tailwindcss/migration-from-tailwind-2 -->
-                  <image :href="tournament?.casters[1].image" class="overflow-clip" width="3.5" height="3" y="4.5"/>
-                </a>
-                <text font-size="1" text-anchor="middle" x="4" y="4.25">&</text>
-              </g>
-            </svg>
-          </div>
-        </div>
-      </div>
-    </section>
+    <TournamentGroups v-if="selected_section === 'groups'" :tournament="tournament"/>
 
-    <section id="teams" :class="{ hidden: !sections.teams[0] }">
-      <h1 v-if="tournament?.teams.length === 0" class="mt-6 text-center text-4xl">
-        Aucune équipe inscrite
-      </h1>
-      <div v-if="tourney_teams?.validated_teams.length > 0">
-        <h1 class="title">
-          Équipes validées
-        </h1>
-        <div class="grid gap-4 p-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          <TeamCard v-for="team in tourney_teams.validated_teams" :key="team.id" :team="team"/>
-        </div>
-      </div>
-      <div v-if="tourney_teams?.non_validated_teams.length > 0">
-        <h1 class="title">
-          Équipes en cours de validation
-        </h1>
-        <div class="grid gap-4 p-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-          <TeamCard v-for="team in tourney_teams.non_validated_teams" :key="team.id" :team="team"/>
-        </div>
-      </div>
-    </section>
+    <TournamentSwiss v-if="selected_section === 'swiss'" :tournament="tournament"/>
 
-    <section id="groups" :class="{ hidden: !sections.groups[0] || show_detail_group }" class="flex content-center">
-      <h1 v-if="tournament?.groups?.length === 0 && tournament?.swissRounds.length === 0" class="mt-6 flex flex-1 justify-center text-center text-4xl">
-        Les poules ou les rondes suisse ne sont pas disponibles.
-      </h1>
-      <div v-if="tournament?.groups?.length > 0" class="my-10 flex flex-1 flex-wrap justify-center gap-20">
-        <div
-          v-for="group in tournament?.groups"
-          :key="group.id"
-          class=" m-2 border-collapse border-slate-500 hover:ring-8 hover:ring-slate-500 md:m-0 md:w-2/5"
-          @click="show_detail_group = group.id"
-          @keydown.enter="show_detail_group = group.id"
-        >
-          <GroupTable
-            :teams="tourney_teams"
-            :group="group"
-          />
-        </div>
-      </div>
-      <div v-else-if="tournament?.swissRounds?.length > 0" class="mt-6 flex h-full justify-center">
-        <div v-for="swiss in tournament?.swissRounds" :key="swiss.id" class="mx-3 overflow-x-auto">
-          <SwissRoundTable
-            :rounds="swiss_match_results(swiss.matchs)"
-            :team-per-match="tournament?.game.team_per_match"
-            :round-count="2 * swiss.min_score - 1"
-          />
-        </div>
-      </div>
-    </section>
+    <TournamentBrackets v-if="selected_section === 'knockouts'" :tournament="tournament"/>
 
-    <section v-if="get_group_by_id(tournament?.groups || [], show_detail_group) !== undefined" id="group" :class="{ hidden: show_detail_group === null || !sections.groups[0] }" class="flex flex-col p-4">
-      <nav class="my-5 flex justify-center gap-3">
-        <button type="button" class="w-full justify-center rounded-md bg-blue-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm hover:bg-blue-500 sm:ml-3 sm:w-auto" @click="show_detail_group = 0">
-          <fa-awesome-icon icon="fa-solid fa-arrow-left"/> Retour
-        </button>
-        <h1 class="text-center text-3xl font-black">
-          {{ get_group_by_id(tournament?.groups, show_detail_group)?.name }}
-        </h1>
-      </nav>
-      <div class="flex flex-col justify-center gap-10 md:flex-row md:gap-3">
-        <div class="max-h-96 md:ml-10 md:w-1/2">
-          <GroupTable
-            :teams="tourney_teams"
-            :group="get_group_by_id(tournament.groups, show_detail_group) as Group"
-          />
-        </div>
-        <div class="flex flex-col-reverse md:w-1/2">
-          <div
-            v-for="matchs in get_matchs_per_round(get_group_by_id(tournament.groups, show_detail_group)?.matchs ?? [])"
-            :key="matchs[0].id"
-          >
-            <h1 class="text-center text-3xl font-black">
-              Round {{ matchs[0].round_number }}
-            </h1>
-            <div class="gap-4">
-              <div v-for="game in matchs" :key="game.id">
-                <div v-if="game.teams.length == 2" class="flex justify-center">
-                  <div class="mb-4 flex flex-1 justify-between divide-x overflow-hidden border-2 text-xl font-bold md:ml-10">
-                    <div class="w-full truncate p-3">
-                      {{ get_validated_team_by_id(game.teams[0])?.name || "TBD" }}
-                    </div>
-                    <div class="p-3">
-                      {{ game.score[game.teams[0]] }}
-                    </div>
-                  </div>
-                  <div class="mb-4 flex flex-1 divide-x overflow-hidden border-2 text-xl font-bold md:mr-10">
-                    <div class="p-3">
-                      {{ game.score[game.teams[1]] }}
-                    </div>
-                    <div class="w-full truncate p-3 text-right">
-                      {{ get_validated_team_by_id(game.teams[1])?.name || "TBD" }}
-                    </div>
-                  </div>
-                </div>
-                <div v-else class="flex justify-center">
-                  <div>
-                    <div class="mx-5 mb-4 flex flex-1 justify-between divide-x border-2 text-xl font-bold">
-                      <table>
-                        <tr>
-                          <th align="center" class="troncate border-separate border border-slate-500 bg-slate-200 p-4 text-black">
-                            Equipe
-                          </th>
-                          <th align="center" class="border-separate border border-slate-500 bg-slate-200 p-4 text-black">
-                            Score
-                          </th>
-                        </tr>
-                        <tr v-for="team_id in game.teams" :key="team_id">
-                          <td align="center" class="border-separate border border-slate-500 p-4">
-                            {{ get_validated_team_by_id(team_id)?.name || "TBD" }}
-                          </td>
-                          <td align="center" class="border-separate border border-slate-500 p-4">
-                            {{ game.score[team_id] }}
-                          </td>
-                        </tr>
-                      </table>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+    <TournamentPlanning v-if="selected_section === 'planning'" :tournament="tournament"/>
 
-    <section id="brackets" :class="{ hidden: !sections.brackets[0] }">
-      <!-- TODO: refactor in component -->
-      <h1 v-if="tournament?.brackets?.length === 0" class="mt-6 text-center text-4xl">
-        Les arbres ne sont pas disponibles.
-      </h1>
-      <div v-for="bracket in tournament.brackets" v-else :key="bracket.id">
-        <h1 class="title">
-          {{ bracket.name }}
-        </h1>
-        <div v-if="bracket.bracket_type === BracketType.SINGLE" :key="bracket.id" class="overflow-x-auto">
-          <div class="grid items-center gap-10" :style="get_col_style(bracket)">
-            <div v-for="(games, round_idx) in get_matchs_per_round(bracket.matchs)" :key="round_idx" class="flex h-full flex-col justify-around">
-              <div v-for="game in games" :key="game.id" class="m-2 divide-y">
-                <KnockoutMatchCard
-                  :team-per-match="tournament.game.team_per_match"
-                  :teams="knockout_match_results(game as KnockoutMatch)"
-                  :status="game.status"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-        <div v-if="bracket.bracket_type === BracketType.DOUBLE" :key="bracket.id" class="overflow-x-auto">
-          <div class="grid h-full items-center gap-10" :style="get_col_style(bracket)">
-            <div class="flex h-full flex-col justify-around">
-              <div v-for="game in get_winner_matchs_per_round(bracket.matchs, bracket.depth)" :key="game.id" class="m-2 divide-y">
-                <KnockoutMatchCard
-                  :team-per-match="tournament.game.team_per_match"
-                  :teams="knockout_match_results(game)"
-                  :status="game.status"
-                />
-              </div>
-            </div>
-            <div v-for="col_idx in get_bracket_cols_count(bracket) - 2" :key="col_idx" class="flex h-full flex-col">
-              <div v-if="col_idx % 2" class="flex h-full flex-col justify-around">
-                <div v-for="game in get_winner_matchs_per_round(bracket.matchs, bracket.depth - (col_idx - 1) / 2 - 1)" :key="game.id" class="m-2 divide-y">
-                  <KnockoutMatchCard
-                    :team-per-match="tournament.game.team_per_match"
-                    :teams="knockout_match_results(game)"
-                    :status="game.status"
-                  />
-                </div>
-              </div>
-            </div>
-            <div v-if="bracket.winner !== null" class="w-40 bg-yellow-600 p-2">
-              <h1 class="text-bold text-center text-2xl">
-                Vainqueur
-              </h1>
-              <p class="text-center text-xl">
-                {{ get_validated_team_by_id(bracket.winner)?.name }}
-              </p>
-            </div>
-          </div>
-          <div class="grid items-center gap-10" :style="get_col_style(bracket)">
-            <div/>
-            <div v-for="(games, round_idx) in get_looser_matchs(bracket.matchs)" :key="round_idx" class="flex h-full flex-col justify-around">
-              <div v-for="game in games" :key="game.id" class="m-2 divide-y">
-                <KnockoutMatchCard
-                  :team-per-match="tournament.game.team_per_match"
-                  :teams="knockout_match_results(game)"
-                  :status="game.status"
-                />
-              </div>
-            </div>
-            <div/>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="planning" :class="{ hidden: !sections.planning[0] }">
-      <div class="m-1 flex justify-center rounded bg-cyan-900 p-2">
-        Les plannings peuvent varier en fonction de l'avancement des tournois et sont donnés à titre indicatif.
-      </div>
-      <div v-if="!getContent(tournament?.planning)" class="flex justify-center">
-        Le planning n'est pas encore disponible, revenez plus tard !
-      </div>
-      <div class="flex justify-center">
-        <div class="m-2 overflow-auto overscroll-y-auto">
-          <content :name="tournament?.planning"/>
-        </div>
-      </div>
-    </section>
-
-    <section id="rules" :class="{ hidden: !sections.rules[0] }">
-      <!-- eslint-disable-next-line vue/no-v-html -->
-      <div class="mx-auto my-4 w-[min(1080px,90%)] text-justify" v-html="md.render(tournament?.rules)"/>
-    </section>
+    <TournamentRules v-if="selected_section === 'rules'" :tournament="tournament"/>
   </div>
-
   <div v-else class="mt-6 text-center text-4xl">
     Le tournoi que vous cherchez n'a pas encore été annoncé, revenez plus tard !
   </div>
 </template>
-
-<style scoped>
-section {
-  flex-grow: 1;
-  width: 100%;
-  height: 100%;
-  overflow-x: scroll;
-}
-
-a {
-  @apply text-xl
-}
-
-@media (max-width: 768px)  {
-  .dropGrow {
-    animation: 300ms ease-in-out growDown;
-    animation-direction: alternate;
-  }
-
-  @keyframes growDown {
-    0% {
-      transform: translateY(2.5rem) scaleY(0);
-    }
-    80% {
-      transform: translateY(2.5rem) scaleY(1.1);
-    }
-    100% {
-      transform: translateY(2.5rem) scaleY(1);
-    }
-  }
-}
-</style>

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -45,8 +45,8 @@ try {
 </script>
 
 <template>
-  <div v-if="tournament?.is_announced" class="min-h-[calc(100vh_-_6rem)]">
-    <div class="sticky top-24 min-w-full bg-[#2c292d]">
+  <div v-if="tournament?.is_announced" class="flex min-h-[calc(100vh_-_6rem)] flex-col">
+    <div class="sticky top-24 bg-[#2c292d]">
       <div class="text-center text-6xl font-bold text-white">
         {{ tournament?.name }}
       </div>

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 }>();
 
 const tournamentStore = useTournamentStore();
-const { getTournamentFull } = tournamentStore;
+const { getTournamentFull, getTournamentTeams } = tournamentStore;
 const { tournament } = storeToRefs(tournamentStore);
 
 const open_dropdown = ref(false);
@@ -38,6 +38,7 @@ const selected_section = ref<string>(route.path.split('/').at(-1));
 
 try {
   await getTournamentFull(props.id);
+  getTournamentTeams();
 } catch (err: unknown) {
   router.go(-1);
 }

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useTournamentStore } from '@/stores/tournament.store';
 
 const props = defineProps<{
   id: number;
-  selectedSection?: string;
 }>();
 
 const tournamentStore = useTournamentStore();
@@ -22,8 +21,6 @@ interface TournamentDetailSection {
   is_selected: boolean;
 }
 
-const selected_section = ref<string>('info');
-
 const sections = computed<Record<string, TournamentDetailSection[]>>(() => ({
   info: { title: 'Informations', is_available: true },
   teams: { title: 'Équipes', is_available: true },
@@ -35,6 +32,9 @@ const sections = computed<Record<string, TournamentDetailSection[]>>(() => ({
 }));
 
 const router = useRouter();
+const route = useRoute();
+
+const selected_section = ref<string>(route.path.split('/').at(-1));
 
 try {
   await getTournamentFull(props.id);

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -2,13 +2,6 @@
 import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
-import TournamentBrackets from '@/components/TournamentBrackets.vue';
-import TournamentGroups from '@/components/TournamentGroups.vue';
-import TournamentInfo from '@/components/TournamentInfo.vue';
-import TournamentPlanning from '@/components/TournamentPlanning.vue';
-import TournamentRules from '@/components/TournamentRules.vue';
-import TournamentSwiss from '@/components/TournamentSwiss.vue';
-import TournamentTeams from '@/components/TournamentTeams.vue';
 import { useTournamentStore } from '@/stores/tournament.store';
 
 const props = defineProps<{
@@ -36,30 +29,12 @@ const sections = computed<Record<string, TournamentDetailSection[]>>(() => ({
   teams: { title: 'Équipes', is_available: true },
   groups: { title: 'Poules', is_available: tournament.value?.groups.length > 0 || false },
   swiss: { title: 'Système Suisse', is_available: tournament.value?.swissRounds.length > 0 || false },
-  knockouts: { title: 'Arbres', is_available: tournament.value?.brackets.length > 0 || false },
+  brackets: { title: 'Arbres', is_available: tournament.value?.brackets.length > 0 || false },
   planning: { title: 'Planning', is_available: true },
   rules: { title: 'Règlement', is_available: true },
 }));
 
-const select_section = (e: Event) => {
-  const target = e.target as HTMLInputElement;
-  selected_section.value = target.id;
-  // Object.keys(sections).forEach((s) => {
-  //   sections[s].is_selected = false;
-  // });
-  // sections[target.id].is_selected = true;
-};
-
 const router = useRouter();
-
-if (props.selectedSection !== '') {
-  if (!(props.selectedSection in sections.value)) {
-    router.go(-1);
-  }
-
-  selected_section.value = props.selectedSection;
-  // sections[props.selectedSection].is_selected = true;
-}
 
 try {
   await getTournamentFull(props.id);
@@ -76,37 +51,29 @@ try {
       </div>
 
       <nav class="mt-2 flex justify-center bg-gray-500 py-4 ">
-        <div class="flex w-2/3 justify-between xl:w-1/2">
+        <div class="flex w-2/3 justify-between xl:w-3/5">
           <template v-for="(section, key) in sections" :key="key">
-            <button
+            <router-link
               v-if="section.is_available"
-              :id="key"
+              :to="key"
               :class="{ 'underline decoration-[#63d1ff] decoration-4 underline-offset-8': key === selected_section }"
-              type="button"
               class="text-xl"
-              @click="select_section"
+              @click="selected_section = key"
             >
               {{ section.title }}
-            </button>
+            </router-link>
           </template>
         </div>
       </nav>
     </div>
     {{ sections }}
 
-    <TournamentInfo v-if="selected_section === 'info'" :tournament="tournament"/>
-
-    <TournamentTeams v-if="selected_section === 'teams'" :tournament="tournament"/>
-
-    <TournamentGroups v-if="selected_section === 'groups'" :tournament="tournament"/>
-
-    <TournamentSwiss v-if="selected_section === 'swiss'" :tournament="tournament"/>
-
-    <TournamentBrackets v-if="selected_section === 'knockouts'" :tournament="tournament"/>
-
-    <TournamentPlanning v-if="selected_section === 'planning'" :tournament="tournament"/>
-
-    <TournamentRules v-if="selected_section === 'rules'" :tournament="tournament"/>
+    <RouterView v-slot="{ Component }">
+      <component
+        :is="Component"
+        :tournament="tournament"
+      />
+    </RouterView>
   </div>
   <div v-else class="mt-6 text-center text-4xl">
     Le tournoi que vous cherchez n'a pas encore été annoncé, revenez plus tard !

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -82,7 +82,6 @@ try {
         </div>
       </nav>
     </div>
-    {{ sections }}
 
     <RouterView v-slot="{ Component }">
       <component

--- a/src/views/TournamentDetail.vue
+++ b/src/views/TournamentDetail.vue
@@ -21,7 +21,7 @@ interface TournamentDetailSection {
   is_selected: boolean;
 }
 
-const sections = computed<Record<string, TournamentDetailSection[]>>(() => ({
+const sections = computed<Record<string, TournamentDetailSection>>(() => ({
   info: { title: 'Informations', is_available: true },
   teams: { title: 'Équipes', is_available: true },
   groups: { title: 'Poules', is_available: tournament.value?.groups.length > 0 || false },
@@ -34,7 +34,10 @@ const sections = computed<Record<string, TournamentDetailSection[]>>(() => ({
 const router = useRouter();
 const route = useRoute();
 
-const selected_section = ref<string>(route.path.split('/').at(-1));
+const selected_section = computed<string>(() => {
+  const sec = route.path.split('/').at(-1);
+  return sec === undefined ? '' : sec;
+});
 
 try {
   await getTournamentFull(props.id);

--- a/src/views/TournamentRegister.vue
+++ b/src/views/TournamentRegister.vue
@@ -138,6 +138,8 @@ if (Date.parse(tournament.value?.registration_open ?? '') > Date.now()) {
 }
 
 const host = import.meta.env.VITE_WEBSITE_HOST as string;
+
+const view_password = ref<boolean>(false);
 </script>
 
 <template>
@@ -199,7 +201,15 @@ const host = import.meta.env.VITE_WEBSITE_HOST as string;
             <label for="pwd">
               Mot de passe
             </label>
-            <input id="pwd" v-model="register_form.password" class="text-black" :class="{ error: context.invalid }" type="text"/>
+            <input id="pwd" v-model="register_form.password" class="text-black" :class="{ error: context.invalid }" :type="view_password ? 'text' : 'password'"/>
+            <fa-awesome-icon
+              :icon="['fas', view_password ? 'eye-slash' : 'eye']"
+              class="absolute right-8 top-10 z-10"
+              size="s"
+              title="Voir le mot de passe"
+              style="color: black;"
+              @click="view_password = !view_password"
+            />
             <button type="button" @click="generate_password">
               <fa-awesome-icon
                 v-if="create"
@@ -237,7 +247,7 @@ const host = import.meta.env.VITE_WEBSITE_HOST as string;
         <FormField v-slot="context" :validations="v$.accept_rules" class="flex flex-col self-center text-3xl">
           <div>
             <input id="check" v-model="register_form.accept_rules" :class="{ error: context.invalid }" type="checkbox"/>
-            <label for="check"> J'accepte les <router-link :to="`/tournament/${tournament?.id}?s=rules`" target="_blank" class="text-[#63d1ff]">règles du tournoi</router-link></label>
+            <label for="check"> J'accepte les <router-link :to="`/tournament/${tournament?.id}/rules`" target="_blank" class="text-[#63d1ff]">règles du tournoi</router-link></label>
           </div>
         </FormField>
       </div>
@@ -304,7 +314,7 @@ const host = import.meta.env.VITE_WEBSITE_HOST as string;
         Continuer & payer
       </button>
       <router-link
-        :to="`/tournament/${tournament?.id}?s=teams`"
+        :to="`/tournament/${tournament?.id}/teams`"
         class="inline-flex w-full justify-center rounded-md bg-green-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 sm:ml-3 sm:w-auto"
       >
         Continuer


### PR DESCRIPTION
## Description

Rework Tournament page to split code into components, switch to nested routes instead of manual routing for sub-pages, split groups/swiss sub-page into separate sub-pages and hide groups/swiss/brackets sub-pages if no information available.

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [x] I have tested the responsiveness of the changes and they work as expected.
- [x] I have assigned the pull request to the appropriate reviewer(s).
- [x] I have added labels to the pull request, if necessary.

## Related Issues

Fix #130.

