### PR TITLE
Split workflow in multiple jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
 on: pull_request
 jobs:
-  build:
+  Lint:
     runs-on: ubuntu-latest
+    # Continue to the next step even if this fails
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -16,12 +18,23 @@ jobs:
         # Continue to the next step even if this fails
         continue-on-error: true
 
-      - name: Typecheck
-        run: npx vue-tsc --noEmit
-        # Continue to the next step even if this fails
-        continue-on-error: true
-
       - name: Annotate Code Linting Results
         uses: ataylorme/eslint-annotate-action@v2
         with:
           markdown-report-on-step-summary: true
+
+  Typecheck:
+    runs-on: ubuntu-latest
+    # Continue to the next step even if this fails
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Run Typecheck
+        run: npx vue-tsc --noEmit


### PR DESCRIPTION
## Description

With continue-on-error on steps, when that step fail, it marked as succeeded.

However, having continue-on-error at the job level marks the job as failed but continue to the next job.

This PR split the workflow in two jobs to be able to have the job marked as failed when a step fails but continue to the next job.

