### PR TITLE
Display next timeslots in eat view

### DIFF
--- a/src/components/PizzaCard.vue
+++ b/src/components/PizzaCard.vue
@@ -15,19 +15,24 @@ const pizza = computed<Pizza | undefined>(() => pizzaList.value[props.id]);
 
 </script>
 <template>
-  <div class="grid place-items-center bg-cyan-900 shadow-lg">
+  <div class="grid bg-cyan-900 shadow-lg">
     <img
       :alt="`Image de ${pizza?.name}`"
       :src="pizza?.image"
       class="max-w-screen aspect-video h-48 w-full text-clip object-cover"
     />
-    <div class="w-3/4 border-b-2">
-      <p class="text-center text-2xl font-bold">
-        {{ pizza?.name }}
-      </p>
+    <div class="flex h-44 w-full flex-col items-center p-2">
+      <div class="mb-2 w-3/4 border-b-2">
+        <p class="text-center text-2xl font-bold">
+          {{ pizza?.name }}
+        </p>
+      </div>
+      <div class="flex grow items-center">
+        <p class="text-center">
+          <span class="font-black">Ingrédients :</span> {{ pizza?.ingredients.join(', ') }}<br>
+          <span class="font-black">Allergènes :</span> {{ pizza?.allergens.join(', ') }}
+        </p>
+      </div>
     </div>
-    <p class="text-center">
-      Ingrédients : {{ pizza?.ingredients.join(', ') }} <br> Allergènes : {{ pizza?.allergens.join(', ') }}
-    </p>
   </div>
 </template>

--- a/src/components/PizzaCard.vue
+++ b/src/components/PizzaCard.vue
@@ -21,13 +21,13 @@ const pizza = computed<Pizza | undefined>(() => pizzaList.value[props.id]);
       :src="pizza?.image"
       class="max-w-screen aspect-video h-48 w-full text-clip object-cover"
     />
-    <div class="flex h-44 w-full flex-col items-center p-2">
+    <div class="flex w-full flex-col items-center p-2">
       <div class="mb-2 w-3/4 border-b-2">
         <p class="text-center text-2xl font-bold">
           {{ pizza?.name }}
         </p>
       </div>
-      <div class="flex grow items-center">
+      <div class="flex">
         <p class="text-center">
           <span class="font-black">Ingrédients :</span> {{ pizza?.ingredients.join(', ') }}<br>
           <span class="font-black">Allergènes :</span> {{ pizza?.allergens.join(', ') }}

--- a/src/views/Eat.vue
+++ b/src/views/Eat.vue
@@ -1,26 +1,60 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
 import Content from '@/components/Content.vue';
 import PizzaCard from '@/components/PizzaCard.vue';
 import { usePizzaStore } from '@/stores/pizza.store';
+import { frenchFormatFromDate } from '@/utils';
 
 const pizzaStore = usePizzaStore();
-const { pizzaList } = storeToRefs(pizzaStore);
+const { timeslotList, pizzaList } = storeToRefs(pizzaStore);
 
-const { fetchAllPizzas } = pizzaStore;
+const { fetchAllPizzas, fetchNextTimeslots } = pizzaStore;
+
+const sortedTimeslotList = computed(() => Object.values(timeslotList.value).sort((pizza1, pizza2) => {
+  const time1 = new Date(pizza1.delivery_time).getTime();
+  const time2 = new Date(pizza2.delivery_time).getTime();
+  return time1 - time2;
+}));
+
+const pizzas = computed(() => {
+  if (sortedTimeslotList.value.length === 0) {
+    return pizzaList.value;
+  }
+
+  return Object.values(pizzaList.value)
+    .filter((pizza) => sortedTimeslotList.value[0].pizza.includes(pizza.id));
+});
 
 await fetchAllPizzas();
+await fetchNextTimeslots();
 </script>
 
 <template>
-  <Content name="Restauration"/>
+  <h1 class="title y-2 text-white">
+    Restauration
+  </h1>
+  <Content class="mb-8 flex flex-col gap-8 lg:px-24 [&_p]:indent-12" name="Restauration"/>
+  <section v-if="sortedTimeslotList.length" class="mx-4 mb-8 lg:px-24">
+    <h1 class="title mb-8 text-white">
+      Prochains créneaux
+    </h1>
+    <p>
+      Les prochains créneaux sont :
+    </p>
+    <ul class="list-disc">
+      <li v-for="timeslot in sortedTimeslotList" :key="timeslot.id" class="ml-16">
+        Créneau {{ frenchFormatFromDate(new Date(timeslot.delivery_time)) }}
+      </li>
+    </ul>
+  </section>
   <section>
-    <div class="title my-2 text-white">
-      Pizza
-    </div>
-    <div class="mb-12 grid w-full gap-4 px-4 md:grid-cols-2 xl:grid-cols-4">
+    <h1 class="title mb-8 text-white">
+      Pizzas {{ sortedTimeslotList.length ? 'du Prochain Créneau' : '' }}
+    </h1>
+    <div class="mb-12 grid w-full grid-cols-1 gap-4 px-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
       <PizzaCard
-        v-for="pizza in pizzaList"
+        v-for="pizza in pizzas"
         :id="pizza.id"
         :key="pizza.id"
       />


### PR DESCRIPTION
## Description

Display next timeslots in eat view.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have tested the responsiveness of the changes and they work as expected.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

## Related Issues

Fix #131 

## Screenshots
![2024-11-26-085636_hyprshot](https://github.com/user-attachments/assets/c9aa03a5-0b98-46d0-8f87-f8141cef13dd)

