### PR TITLE
Prevent solo game's teams name edition

### DIFF
--- a/src/views/TeamDetail.vue
+++ b/src/views/TeamDetail.vue
@@ -25,7 +25,7 @@ const {
   getTournamentFull, getTournamentTeams, patch_registration, patch_team, leave_team,
 } = tournamentStore;
 const { fetch_user_inscription_full } = userStore;
-const { tournament } = storeToRefs(tournamentStore);
+const { tournament, soloGame } = storeToRefs(tournamentStore);
 // const { fetch_user_inscription_full, patch_user, send_score } = userStore;
 const { inscriptions } = storeToRefs(userStore);
 
@@ -235,7 +235,8 @@ const kick_member = async (type: string, id: number) => {
         </div>
         <button
           v-if="
-            (tournament as TournamentDeref)?.event.ongoing
+            !soloGame
+              && (tournament as TournamentDeref)?.event.ongoing
               && (
                 team_registration?.[0] === 'manager'
                 || (


### PR DESCRIPTION
## Description

Prevent solo game's teams name edition by removing the button when the game is a solo game.

## Checklist

- [x] I have tested the changes locally and they work as expected.
- [X] I have tested the responsiveness of the changes and they work as expected.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

## Related Issues

Fix #164

