### PR TITLE
Fix non ongoing tournament team edition.

### DIFF
--- a/src/stores/tournament.store.ts
+++ b/src/stores/tournament.store.ts
@@ -199,7 +199,8 @@ export const useTournamentStore = defineStore('tournament', () => {
 
   async function getPrivateTournament(id: number) {
     if (!(id in privateTournamentsList.value)) {
-      await fetchPrivateTournaments();
+      const res = await axios<PrivateTournament>(`tournament/tournament/privates/${id}/`);
+      privateTournamentsList.value[id] = res.data;
     }
     tournament.value = privateTournamentsList.value[id];
   }

--- a/src/views/TeamDetail.vue
+++ b/src/views/TeamDetail.vue
@@ -22,7 +22,7 @@ const tournamentStore = useTournamentStore();
 const userStore = useUserStore();
 
 const {
-  getTournamentFull, getTournamentTeams, patch_registration, patch_team, leave_team, getPrivateTournaments,
+  getTournamentFull, getTournamentTeams, patch_registration, patch_team, leave_team, getPrivateTournament,
 } = tournamentStore;
 const { fetch_user_inscription_full } = userStore;
 const { tournament, soloGame, privateTournamentsList } = storeToRefs(tournamentStore);
@@ -59,7 +59,7 @@ const selected_team = computed(() => (
 
 try {
   if (Object.keys(privateTournamentsList.value).length === 0) {
-    await getPrivateTournaments();
+    await getPrivateTournament(props.id);
   }
 
   if (props.id in privateTournamentsList.value) {


### PR DESCRIPTION
## Description

When a private tournament is not ongoing anymore, there was a bug where the team view will not be able to access team page.

## Checklist

- [X] I have tested the changes locally and they work as expected.
- [X] I have tested the responsiveness of the changes and they work as expected.
- [X] I have assigned the pull request to the appropriate reviewer(s).
- [X] I have added labels to the pull request, if necessary.

